### PR TITLE
fix: Parse dstack domain correctly for TEE registration

### DIFF
--- a/deployment/local_agent_server.py
+++ b/deployment/local_agent_server.py
@@ -431,8 +431,15 @@ async def register_tee():
 
     print(f"🔍 AGENT_DOMAIN: {agent_domain}")
 
-    app_id = agent_domain.split('-')[0] if '-' in agent_domain else agent_domain.split('.')[0]
-    dstack_domain = agent_domain.split('.', 1)[1] if '.' in agent_domain else ''
+    # Parse domain: format is {app_id}-{port}.{dstack_domain} or localhost:port for dev
+    if '-' in agent_domain and '.' in agent_domain:
+        # Production: app_id-port.dstack_domain
+        app_id = agent_domain.split('-')[0]
+        dstack_domain = agent_domain.split('.', 1)[1]
+    else:
+        # Local dev: localhost:port or just domain
+        app_id = agent_domain.split(':')[0].split('.')[0]
+        dstack_domain = os.getenv('DSTACK_GATEWAY_DOMAIN', 'local.dev')
 
     print(f"🔍 app_id: {app_id}")
     print(f"🔍 dstack_domain: {dstack_domain}")


### PR DESCRIPTION
- Handle both production format (app_id-port.gateway_domain) and local dev (localhost:port)
- Fixes empty dstackDomain error in offchain proof request
- Production domains now correctly extract app_id and dstack_domain
- Local dev uses DSTACK_GATEWAY_DOMAIN env or defaults to local.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)