### PR TITLE
feat: add trust center to Agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ AGENT_SALT=your-unique-production-salt-here
 # In VibeVM set the address to your domain e.g. AGENT_DOMAIN=7f56b605ad6c5f28743a6dac6481cf272f2f610a-8000.dstack-pha-prod9.phala.network
 AGENT_DOMAIN=<dstack-app-id>-8000.<dstack-gateway-domain>
 
+# Trust Center Configuration
+# URL to the Phala Network TEE attestation widget
+# Go to https://trust.phala.com/app/<dstack-app-id> to create your custom widget
+# Format: https://trust.phala.com/widget/app/<dstack-app-id>/<widget-id>
+TRUST_CENTER_URL=https://trust.phala.com/widget/app/<dstack-app-id>/<widget-id>
+
 # Blockchain Configuration
 RPC_URL=https://1rpc.io/sepolia
 CHAIN_ID=11155111

--- a/deployment/local_agent_server.py
+++ b/deployment/local_agent_server.py
@@ -258,6 +258,17 @@ async def get_chain_config():
     return config
 
 
+@app.get("/api/trust-center-url")
+async def get_trust_center_url():
+    """Get trust center URL from environment."""
+    trust_center_url = os.getenv("TRUST_CENTER_URL", "")
+
+    if not trust_center_url:
+        raise HTTPException(status_code=404, detail="Trust center URL not configured")
+
+    return {"trust_center_url": trust_center_url}
+
+
 @app.get("/api/wallet")
 async def get_wallet():
     """Get wallet address and balance for funding."""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       - GITHUB_REPO=${GITHUB_REPO:-https://github.com/Phala-Network/erc-8004-tee-agent.git}
       - GIT_COMMIT_HASH=${GIT_COMMIT_HASH:-HEAD}
       - UPDATE_CODE=${UPDATE_CODE:-false}
+      - TRUST_CENTER_URL=${TRUST_CENTER_URL:-https://trust.phala.com/widget/app/${DSTACK_APP_ID}}
 
       # Agent configuration
       - AGENT_DOMAIN=${DSTACK_APP_ID}-8000.${DSTACK_GATEWAY_DOMAIN}

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -6,6 +6,7 @@
     <title>TEE Agent Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/static/wallet-utils.js"></script>
+    <script src="/static/trust-center.js"></script>
 </head>
 <body class="bg-gray-900 text-white">
     <div class="container mx-auto px-4 py-8 max-w-6xl">

--- a/static/developer.html
+++ b/static/developer.html
@@ -6,6 +6,7 @@
     <title>TEE Agent - Developer API</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="/static/wallet-utils.js"></script>
+    <script src="/static/trust-center.js"></script>
 </head>
 <body class="bg-gray-900 text-white">
     <div class="container mx-auto px-4 py-8 max-w-7xl">

--- a/static/funding.html
+++ b/static/funding.html
@@ -7,6 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>
     <script src="/static/wallet-utils.js"></script>
+    <script src="/static/trust-center.js"></script>
 </head>
 <body class="bg-gray-900 text-white">
     <div class="container mx-auto px-4 py-8 max-w-4xl">

--- a/static/trust-center.js
+++ b/static/trust-center.js
@@ -1,0 +1,140 @@
+/**
+ * Trust Center Popup Component
+ * Displays Phala Network TEE attestation widget in a modal popup
+ */
+
+class TrustCenterPopup {
+    constructor(iframeUrl) {
+        this.iframeUrl = iframeUrl;
+        this.modal = null;
+        this.isOpen = false;
+    }
+
+    init() {
+        // Create modal HTML
+        const modalHTML = `
+            <div id="trustCenterModal" class="hidden fixed inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center p-4">
+                <div class="bg-gray-800 rounded-lg overflow-hidden flex flex-col shadow-2xl relative" style="width: 382px;">
+                    <!-- Modal Header -->
+                    <div class="p-4 border-b border-gray-700 text-center">
+                        <h2 class="text-lg font-bold flex items-center justify-center gap-2">
+                            🔒 TEE Trust Center
+                        </h2>
+                        <p class="text-xs text-gray-400 mt-1">Powered by Phala Cloud</p>
+                        <button onclick="trustCenter.close()" class="text-gray-400 hover:text-white text-2xl leading-none transition-colors absolute top-2 right-2" aria-label="Close">
+                            ×
+                        </button>
+                    </div>
+
+                    <!-- Iframe Container -->
+                    <div class="overflow-hidden bg-white" style="height: 800px;">
+                        <iframe
+                            src="${this.iframeUrl}"
+                            width="100%"
+                            height="800"
+                            frameborder="0"
+                            class="w-full h-full"
+                            title="Phala Cloud Trust Center"
+                        ></iframe>
+                    </div>
+                </div>
+            </div>
+        `;
+
+        // Create floating badge HTML
+        const badgeHTML = `
+            <button
+                onclick="trustCenter.open()"
+                class="fixed bottom-6 right-6 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white px-6 py-3 rounded-full shadow-lg flex items-center gap-2 transition-all hover:scale-105 z-40 group"
+                aria-label="View TEE Attestation"
+            >
+                <span class="text-xl">🔒</span>
+                <span class="font-bold">TEE Verified</span>
+                <div class="absolute -top-1 -right-1 w-3 h-3 bg-green-500 rounded-full animate-pulse"></div>
+            </button>
+        `;
+
+        // Inject HTML into body
+        document.body.insertAdjacentHTML('beforeend', modalHTML);
+        document.body.insertAdjacentHTML('beforeend', badgeHTML);
+
+        this.modal = document.getElementById('trustCenterModal');
+
+        // Setup event listeners
+        this.setupEventListeners();
+    }
+
+    setupEventListeners() {
+        // Close on ESC key
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && this.isOpen) {
+                this.close();
+            }
+        });
+
+        // Close on backdrop click
+        this.modal.addEventListener('click', (e) => {
+            if (e.target === this.modal) {
+                this.close();
+            }
+        });
+    }
+
+    open() {
+        this.modal.classList.remove('hidden');
+        this.isOpen = true;
+        // Prevent body scroll when modal is open
+        document.body.style.overflow = 'hidden';
+    }
+
+    close() {
+        this.modal.classList.add('hidden');
+        this.isOpen = false;
+        // Restore body scroll
+        document.body.style.overflow = '';
+    }
+
+    toggle() {
+        if (this.isOpen) {
+            this.close();
+        } else {
+            this.open();
+        }
+    }
+}
+
+// Initialize trust center with URL fetched from backend
+let trustCenter = null;
+
+async function initializeTrustCenter() {
+    try {
+        // Fetch trust center URL from backend API
+        const response = await fetch('/api/trust-center-url');
+
+        if (!response.ok) {
+            console.error('Failed to fetch trust center URL:', response.statusText);
+            return;
+        }
+
+        const data = await response.json();
+        const trustCenterUrl = data.trust_center_url;
+
+        if (!trustCenterUrl) {
+            console.error('Trust center URL not configured');
+            return;
+        }
+
+        // Initialize trust center with fetched URL
+        trustCenter = new TrustCenterPopup(trustCenterUrl);
+        trustCenter.init();
+    } catch (error) {
+        console.error('Error initializing trust center:', error);
+    }
+}
+
+// Initialize on DOM ready
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeTrustCenter);
+} else {
+    initializeTrustCenter();
+}


### PR DESCRIPTION
This pull request introduces a new Trust Center feature that allows users to view the Phala Network TEE attestation widget via a floating badge and modal popup in the frontend. The implementation involves backend API support, environment variable configuration, Docker integration, and frontend enhancements.

**Trust Center Widget Integration:**

* Added a new environment variable `TRUST_CENTER_URL` (with documentation) to `.env.example` for specifying the Phala Trust Center widget URL.
* Updated `docker-compose.yml` to pass the `TRUST_CENTER_URL` environment variable to the agent service, ensuring the widget URL is available in containerized deployments.

**Backend Support:**

* Implemented a new API endpoint `/api/trust-center-url` in `local_agent_server.py` to provide the Trust Center widget URL to frontend clients, returning a 404 if not configured.

**Frontend Integration:**

* Added `trust-center.js`, a reusable JavaScript component that fetches the Trust Center URL from the backend and displays the widget in a modal popup with a floating "TEE Verified" badge.
* Included the new `trust-center.js` script in all relevant frontend HTML files (`dashboard.html`, `developer.html`, `funding.html`) to enable the Trust Center feature across the application. [[1]](diffhunk://#diff-7361154038c39746d44a8e02224fa3fd120b900bab83fe0d3b50a0eb46597018R9) [[2]](diffhunk://#diff-4875c6667d748ab3ad59a94046e9a90ea022a2ac2054a776479c2a66a6494126R9) [[3]](diffhunk://#diff-4c8dae375bf82c3dc9a5e417b429c5b4db32876d12ca0a2ff5b2fbe8c46985eeR10)